### PR TITLE
Add --max-depth flag to limit directory traversal depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ pr -dir /path/to/your/folder
 
 ### Basic Flags
 
-| Flag | Description | Default | Example |
-|------|-------------|---------|---------|
-| `--dir` | Specify directory to print | Current directory | `pr --dir /path/to/folder` |
-| `--ext` | Filter files by extension | All files | `pr --ext .go` |
-| `--output` | Save output to file | Terminal output | `pr --output output.txt` |
-| `--no-color` | Disable colored output | Colors enabled | `pr --no-color` |
-| `--hidden` | Include hidden files | Not included | `pr --hidden` |
+| Flag           | Description | Default | Example |
+|----------------|-------------|---------|-------|
+| `--dir`        | Specify directory to print | Current directory | `pr --dir /path/to/folder` |
+| `--ext`        | Filter files by extension | All files | `pr --ext .go` |
+| `--output`     | Save output to file | Terminal output | `pr --output output.txt` |
+| `--no-color`   | Disable colored output | Colors enabled | `pr --no-color` |
+| `--hidden`     | Include hidden files | Not included | `pr --hidden` |
+| `--max-depth` | Limit directory traversal depth | No limit | `pr --max-depth 2` |
 
 ### Sorting Flags
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"PrintLayout/pkg/printer"
 	"flag"
+	"fmt"
+	"os"
 )
 
 func main() {
@@ -20,6 +22,7 @@ func main() {
 	flag.StringVar(&config.SortBy, "sort-by", "name", "Sort by 'name', 'size', or 'time'")
 	flag.StringVar(&config.Order, "order", "asc", "Sort order 'asc' or 'desc'")
 	flag.BoolVar(&config.IncludeHidden, "hidden", false, "Include hidden files and directories")
+	flag.IntVar(&config.MaxDepth, "max-depth", -1, "Maximum depth of directory traversal")
 
 	// Add --exclude flag to specify exclusion patterns
 	flag.Func("exclude", "Exclude files/directories matching the pattern (can be specified multiple times)", func(pattern string) error {
@@ -29,6 +32,12 @@ func main() {
 
 	// Parse flags
 	flag.Parse()
+
+	// Validate max-depth
+	if config.MaxDepth < -1 {
+		fmt.Fprintln(os.Stderr, "Error: --max-depth must be -1 (unlimited) or a non-negative integer.")
+		return
+	}
 
 	printer.PrintProjectStructure(
 		config.DirPath,
@@ -43,5 +52,6 @@ func main() {
 		config.SortBy,
 		config.Order,
 		config.IncludeHidden,
+		config.MaxDepth,
 	)
 }

--- a/pkg/printer/printer_bench_test.go
+++ b/pkg/printer/printer_bench_test.go
@@ -24,7 +24,7 @@ func BenchmarkPrintProjectStructure(b *testing.B) {
 	// Run the benchmark
 	b.ResetTimer() // Reset the timer to exclude setup time
 	for i := 0; i < b.N; i++ {
-		PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false)
+		PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 	}
 }
 
@@ -43,7 +43,7 @@ func BenchmarkPrintProjectStructure_JSON(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		PrintProjectStructure(".", "", "", false, "json", "blue", "green", "red", []string{}, "name", "asc", false)
+		PrintProjectStructure(".", "", "", false, "json", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 	}
 }
 
@@ -61,7 +61,7 @@ func BenchmarkPrintProjectStructure_LargeDirectory(b *testing.B) {
 
 	b.ResetTimer() // Reset the timer to exclude setup time
 	for i := 0; i < b.N; i++ {
-		PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false)
+		PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 	}
 }
 

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -29,7 +29,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test text output
 	t.Run("TextOutput", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 		})
 
 		rootName := filepath.Base(tmpDir)
@@ -57,7 +57,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test JSON output
 	t.Run("JSONOutput", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "json", "blue", "green", "red", []string{}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "json", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 		})
 
 		// Verify that the output is valid JSON
@@ -70,7 +70,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test XML output
 	t.Run("XMLOutput", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "xml", "blue", "green", "red", []string{}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "xml", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 		})
 
 		// Verify that the output is valid XML
@@ -83,7 +83,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test YAML output
 	t.Run("YAMLOutput", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "yaml", "blue", "green", "red", []string{}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "yaml", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 		})
 
 		// Verify that the output is valid YAML
@@ -96,7 +96,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test exclusion patterns
 	t.Run("ExclusionPatterns", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{"*.go"}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{"*.go"}, "name", "asc", false, -1)
 		})
 
 		rootName := filepath.Base(tmpDir)
@@ -120,7 +120,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by name (ascending)
 	t.Run("SortByNameAsc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, -1)
 		})
 
 		// Verify that the output is sorted by name in ascending order
@@ -131,7 +131,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by name (descending)
 	t.Run("SortByNameDesc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "desc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "desc", false, -1)
 		})
 
 		// Verify that the output is sorted by name in descending order
@@ -142,7 +142,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by size (ascending)
 	t.Run("SortBySizeAsc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "size", "asc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "size", "asc", false, -1)
 		})
 
 		// Verify that the output is sorted by size in ascending order
@@ -153,7 +153,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by size (descending)
 	t.Run("SortBySizeDesc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "size", "desc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "size", "desc", false, -1)
 		})
 
 		// Verify that the output is sorted by size in descending order
@@ -164,7 +164,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by time (ascending)
 	t.Run("SortByTimeAsc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "time", "asc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "time", "asc", false, -1)
 		})
 
 		// Verify that the output is sorted by time in ascending order
@@ -175,7 +175,7 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test sorting by time (descending)
 	t.Run("SortByTimeDesc", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "time", "desc", false)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "time", "desc", false, -1)
 		})
 
 		// Verify that the output is sorted by time in descending order
@@ -186,12 +186,54 @@ func TestPrintProjectStructure(t *testing.T) {
 	// Test including hidden files
 	t.Run("IncludeHidden", func(t *testing.T) {
 		output := captureOutput(func() {
-			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", true)
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", true, -1)
 		})
 
 		// Verify that the output includes the hidden files
 		// You can add specific checks based on your expected output
 		t.Log(output)
+	})
+
+	// Test maximum depth 0 (should only print the root directory)
+	t.Run("MaxDepthZero", func(t *testing.T) {
+		output := captureOutput(func() {
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, 0)
+		})
+
+		rootName := filepath.Base(tmpDir)
+		expected := rootName + "/\n" +
+			"\n0 directories, 0 files\n"
+		output = strings.TrimSpace(output)
+		expected = strings.TrimSpace(expected)
+
+		if output != expected {
+			t.Errorf("Unexpected output:\nGot:\n%s\nExpected:\n%s", output, expected)
+		}
+	})
+
+	// Test maximum depth 2
+	t.Run("MaxDepthTwo", func(t *testing.T) {
+		output := captureOutput(func() {
+			PrintProjectStructure(".", "", "", false, "text", "blue", "green", "red", []string{}, "name", "asc", false, 2)
+		})
+
+		rootName := filepath.Base(tmpDir)
+
+		expected := rootName + "/\n" +
+			"├── cmd/\n" +
+			"│   └── main.go\n" +
+			"├── go.mod\n" +
+			"├── internal/\n" +
+			"│   └── utils/\n" +
+			"└── pkg/\n" +
+			"    └── printer/\n" +
+			"\n5 directories, 2 files\n"
+		output = strings.TrimSpace(output)
+		expected = strings.TrimSpace(expected)
+
+		if output != expected {
+			t.Errorf("Unexpected output:\nGot:\n%s\nExpected:\n%s", output, expected)
+		}
 	})
 }
 


### PR DESCRIPTION
Fix #19 
- Parsed `--max-depth` as an integer and validated the input.  
- Added tests for `--max-depth 0` and `--max-depth 2` and verified their behavior.  
- Ensured the default behavior remained unchanged.  
- Described `--max-depth` in the README file.  
